### PR TITLE
Add localization-related rules to prevent improper patterns

### DIFF
--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -199,6 +199,7 @@ public let builtInRules: [any Rule.Type] = [
     SwitchCaseOnNewlineRule.self,
     SyntacticSugarRule.self,
     TestCaseAccessibilityRule.self,
+    TextLocalizationRule.self,
     TodoRule.self,
     ToggleBoolRule.self,
     TrailingClosureRule.self,

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -125,6 +125,7 @@ public let builtInRules: [any Rule.Type] = [
     NSLocalizedStringRequireBundleRule.self,
     NSNumberInitAsFunctionReferenceRule.self,
     NSObjectPreferIsEqualRule.self,
+    NavigationTitleRule.self,
     NestingRule.self,
     NimbleOperatorRule.self,
     NoExtensionAccessModifierRule.self,

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -109,6 +109,7 @@ public let builtInRules: [any Rule.Type] = [
     LineLengthRule.self,
     LiteralExpressionEndIndentationRule.self,
     LocalDocCommentRule.self,
+    LocaleOverrideRule.self,
     LowerACLThanParentRule.self,
     MarkRule.self,
     MissingDocsRule.self,
@@ -191,6 +192,7 @@ public let builtInRules: [any Rule.Type] = [
     StatementPositionRule.self,
     StaticOperatorRule.self,
     StrictFilePrivateRule.self,
+    StringLocalizationCorrectArgumentsRule.self,
     StrongIBOutletRule.self,
     SuperfluousElseRule.self,
     SwitchCaseAlignmentRule.self,
@@ -237,8 +239,5 @@ public let builtInRules: [any Rule.Type] = [
     WeakDelegateRule.self,
     XCTFailMessageRule.self,
     XCTSpecificMatcherRule.self,
-    YodaConditionRule.self,
-
-    // Whatnot Rules
-    LocaleOverrideRule.self
+    YodaConditionRule.self
 ]

--- a/Source/SwiftLintBuiltInRules/Rules/Whatnot/NavigationTitleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Whatnot/NavigationTitleRule.swift
@@ -1,0 +1,94 @@
+import SwiftLintCore
+import SwiftSyntax
+
+struct NavigationTitleRule: SwiftSyntaxRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "navigation_title_localization",
+        name: "navigationTitle Localization",
+        description: "Prevents incorrect usage of navigationTitle",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                .navigationTitle(myVariable)
+            """),
+            Example("""
+                NavigationView {
+                    Text(verbatim: "wow")
+                }
+                .navigationTitle(myVariable)
+            """),
+            Example("""
+                NavigationView {
+                    Text(verbatim: "wow")
+                }
+                .navigationTitle(verbatim: "title")
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                Text(wow).↓navigationTitle("title")
+            """),
+            Example("""
+                NavigationView {
+                    Text(verbatim: "wow")
+                }
+                .↓navigationTitle("title")
+            """),
+            Example("""
+                NavigationView {
+                    Text(verbatim: "wow")
+                        .↓navigationTitle("title")
+                }
+            """)
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        Visitor(configuration: configuration, file: file)
+    }
+}
+
+private extension NavigationTitleRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            if let reason = invalidNavigationTitleViolation(node) {
+                violations.append(reason)
+            }
+        }
+    }
+}
+
+private extension NavigationTitleRule.Visitor {
+    func invalidNavigationTitleViolation(_ node: FunctionCallExprSyntax) -> ReasonedRuleViolation? {
+        guard let memberAccessRef = node.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccessRef.declName.baseName.text == "navigationTitle",
+              let firstArgument = node.arguments.first else { return nil }
+
+        let isVerbatimFirstArgumentLabel = firstArgument.label?.text == "verbatim"
+        let hasStringLiteralFirstArgument = firstArgument.expression.as(StringLiteralExprSyntax.self) != nil
+
+        if hasStringLiteralFirstArgument && !isVerbatimFirstArgumentLabel {
+            return reason(
+                position: memberAccessRef.declName.positionAfterSkippingLeadingTrivia,
+                reason: """
+                Avoid calling navigationTitle(_:) with string literals. \
+                Use String.init if this string should be translated, otherwise use navigationTitle(verbatim:)
+                """
+            )
+        }
+
+        return nil
+    }
+}
+
+private extension NavigationTitleRule.Visitor {
+    func reason(position: AbsolutePosition, reason: String) -> ReasonedRuleViolation {
+        .init(
+            position: position,
+            reason: reason,
+            severity: .warning
+        )
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Whatnot/StringLocalizationCorrectArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Whatnot/StringLocalizationCorrectArgumentsRule.swift
@@ -1,0 +1,191 @@
+import SwiftLintCore
+import SwiftSyntax
+
+struct StringLocalizationCorrectArgumentsRule: SwiftSyntaxRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "string_localization",
+        name: "String Localization",
+        description: "Please use String.init(localized:defaultValue:bundle:comment:)",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                String(localized: "a", defaultValue: "b", bundle: .module, comment: "d")
+            """),
+            Example("""
+                AttributedString(localized: "a", defaultValue: "b", bundle: .module, comment: "d")
+            """),
+            Example("""
+                String(
+                    localized: "a",
+                    defaultValue: "b",
+                    bundle: .module,
+                    comment: "d"
+                )
+            """),
+            Example("""
+                .init(
+                    localized: "a",
+                    defaultValue: "b",
+                    bundle: .module,
+                    comment: "d"
+                )
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                ↓String(localized: "a", defaultValue: "b", comment: "d")
+            """),
+            Example("""
+                ↓AttributedString(localized: "a", defaultValue: "b", comment: "d")
+            """),
+            Example("""
+                ↓String(localized: "a", defaultValue: "b", bundle: .module)
+            """),
+            Example("""
+                String(
+                    localized: "a",
+                    defaultValue: "b",
+                    bundle: .module,
+                    ↓comment: ""
+                )
+            """),
+            Example("""
+                AttributedString(
+                    localized: "a",
+                    defaultValue: "b",
+                    bundle: .module,
+                    ↓comment: ""
+                )
+            """),
+            Example("""
+                .init(
+                    localized: "a",
+                    defaultValue: "b",
+                    bundle: .module,
+                    ↓comment: ""
+                )
+            """),
+            Example("""
+                ↓.init(
+                    localized: "a",
+                    defaultValue: "b",
+                    comment: "d"
+                )
+            """),
+            Example("""
+                String(
+                    localized: "a",
+                    ↓defaultValue: myString,
+                    bundle: .module,
+                    comment: "wow"
+                )
+            """),
+            Example("""
+                String(
+                    localized: "a",
+                    ↓defaultValue: isTrue ? "a": "b",
+                    bundle: .module,
+                    comment: "wow"
+                )
+            """)
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        Visitor(configuration: configuration, file: file)
+    }
+}
+
+private extension StringLocalizationCorrectArgumentsRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            if let reason = isInvalidStringLocalizationInitializer(node) {
+                violations.append(reason)
+            } else if let reason = isInvalidTypeInferredStringLocalizationInitializer(node) {
+                violations.append(reason)
+            }
+        }
+    }
+}
+
+private extension StringLocalizationCorrectArgumentsRule.Visitor {
+    func isInvalidStringLocalizationInitializer(_ node: FunctionCallExprSyntax) -> ReasonedRuleViolation? {
+        guard let declRef = node.calledExpression.as(DeclReferenceExprSyntax.self) else { return nil }
+        let isStringInit = declRef.baseName.text == "String"
+        let isAttributedStringInit = declRef.baseName.text == "AttributedString"
+        let hasLocalizedFirstArgument = node.arguments.first?.label?.text == "localized"
+
+        if isStringInit || isAttributedStringInit, hasLocalizedFirstArgument {
+            return hasInvalidArgumentsForStringLocalization(node)
+        }
+
+        return nil
+    }
+
+    func isInvalidTypeInferredStringLocalizationInitializer(_ node: FunctionCallExprSyntax) -> ReasonedRuleViolation? {
+        guard let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self) else {
+            return nil
+        }
+
+        let isTypeInferredInit = calledExpression.base == nil && calledExpression.declName.baseName.text == "init"
+        let hasLocalizedFirstArgument = node.arguments.first?.label?.text == "localized"
+
+        if isTypeInferredInit, hasLocalizedFirstArgument {
+            return hasInvalidArgumentsForStringLocalization(node)
+        }
+
+        return nil
+    }
+
+    func hasInvalidArgumentsForStringLocalization(_ node: FunctionCallExprSyntax) -> ReasonedRuleViolation? {
+        let defaultValueArgument = node.arguments.first { $0.label?.text == "defaultValue" }
+        let bundleArgument = node.arguments.first { $0.label?.text == "bundle" }
+        let commentArgument = node.arguments.first { $0.label?.text == "comment" }
+
+        let hasAllFourArguments = defaultValueArgument != nil && bundleArgument != nil && commentArgument != nil
+        let hasEmptyComment = commentArgument?.expression.as(StringLiteralExprSyntax.self)?.isEmptyString == true
+        let hasLiteralDefaultValueArgument = defaultValueArgument?.expression.as(StringLiteralExprSyntax.self) != nil
+
+        if !hasAllFourArguments {
+            return reason(
+                position: node.positionAfterSkippingLeadingTrivia,
+                reason: """
+                Using String.init(localized:defaultValue:bundle:comment:) with all four arguments \
+                will provide translators with context for the translation
+                """
+            )
+        }
+
+        if hasEmptyComment, let commentArgument {
+            return reason(
+                position: commentArgument.positionAfterSkippingLeadingTrivia,
+                reason: """
+                Comments are required to provide translators with enough context to properly translate the string
+                """
+            )
+        }
+
+        if !hasLiteralDefaultValueArgument, let defaultValueArgument {
+            return reason(
+                position: defaultValueArgument.positionAfterSkippingLeadingTrivia,
+                reason: """
+                Do not perform logic in or pass variables to the defaultValue argument. Only pass string literals
+                """
+            )
+        }
+
+        return nil
+    }
+}
+
+private extension StringLocalizationCorrectArgumentsRule.Visitor {
+    func reason(position: AbsolutePosition, reason: String) -> ReasonedRuleViolation {
+        .init(
+            position: position,
+            reason: reason,
+            severity: .warning
+        )
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Whatnot/TextLocalizationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Whatnot/TextLocalizationRule.swift
@@ -7,7 +7,7 @@ struct TextLocalizationRule: SwiftSyntaxRule {
     static let description = RuleDescription(
         identifier: "text_localization",
         name: "SwiftUI.Text Localization",
-        description: "Please use String.init(localized:defaultValue:bundle:comment:) instead of Text.init",
+        description: "Avoid using SwiftUI.Text.init with string literals",
         kind: .lint,
         nonTriggeringExamples: [
             Example("""
@@ -80,5 +80,4 @@ private extension TextLocalizationRule.Visitor {
     }
 }
 
-// TODO: .navigationTitle("asd")
 // TODO: Picker

--- a/Source/SwiftLintBuiltInRules/Rules/Whatnot/TextLocalizationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Whatnot/TextLocalizationRule.swift
@@ -1,0 +1,84 @@
+import SwiftLintCore
+import SwiftSyntax
+
+struct TextLocalizationRule: SwiftSyntaxRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "text_localization",
+        name: "SwiftUI.Text Localization",
+        description: "Please use String.init(localized:defaultValue:bundle:comment:) instead of Text.init",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                let string = ""
+                Text(string)
+            """),
+            Example("""
+                Text(string)
+            """),
+            Example("""
+                Text(verbatim: "blah")
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                ↓Text("blah")
+            """),
+            Example("""
+                ↓Text("blah", comment: "A nice comment")
+            """),
+            Example("""
+                ↓Text("blah", bundle: .module, comment: "A nice comment")
+            """),
+            // String interpolation
+            Example(#"↓Text("foo \(blah) bar")"#)
+        ]
+    )
+
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        Visitor(configuration: configuration, file: file)
+    }
+}
+
+private extension TextLocalizationRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            if isInvalidTextInitializer(node) {
+                violations.append(reason(position: node.positionAfterSkippingLeadingTrivia))
+            }
+        }
+    }
+}
+
+private extension TextLocalizationRule.Visitor {
+    func isInvalidTextInitializer(_ node: FunctionCallExprSyntax) -> Bool {
+        guard let declRef = node.calledExpression.as(DeclReferenceExprSyntax.self) else { return false }
+        let isTextInit = declRef.baseName.text == "Text"
+        let firstArgument = node.arguments.first
+        let isVerbatimFirstArgumentLabel = firstArgument?.label?.text == "verbatim"
+        let isUntrustedMarkdownFirstArgumentLabel = firstArgument?.label?.text == "untrustedMarkdown"
+        let hasStringLiteralFirstArgument = firstArgument?.expression.as(StringLiteralExprSyntax.self) != nil
+
+        return isTextInit
+            && hasStringLiteralFirstArgument
+            && !isVerbatimFirstArgumentLabel
+            && !isUntrustedMarkdownFirstArgumentLabel
+    }
+}
+
+private extension TextLocalizationRule.Visitor {
+    func reason(position: AbsolutePosition) -> ReasonedRuleViolation {
+        .init(
+            position: position,
+            reason: """
+            Avoid calling Text.init with string literals. \
+            Use String.init if this string should be translated, otherwise use Text.init(verbatim:)
+            """,
+            severity: .warning
+        )
+    }
+}
+
+// TODO: .navigationTitle("asd")
+// TODO: Picker

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -739,6 +739,12 @@ class NSObjectPreferIsEqualRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class NavigationTitleRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NavigationTitleRule.description)
+    }
+}
+
 class NestingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NestingRule.description)

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1183,6 +1183,12 @@ class TestCaseAccessibilityRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class TextLocalizationRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(TextLocalizationRule.description)
+    }
+}
+
 class TodoRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TodoRule.description)

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1141,6 +1141,12 @@ class StrictFilePrivateRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class StringLocalizationCorrectArgumentsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(StringLocalizationCorrectArgumentsRule.description)
+    }
+}
+
 class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StrongIBOutletRule.description)


### PR DESCRIPTION
## Overview

@kelan spends way too much of his time cleaning up our collective localization/translation mess. Hopefully this can help us make fewer mistakes going forward!

## Changes
- Prevent passing incorrect/invalid arguments to `String.init(localized:`
- Prevent passing string literals to `SwiftUI.Text.init`