### PR TITLE
Add rule to prevent use of JSONDecoder.decode(_:from:)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -55,6 +55,7 @@ disabled_rules:
   - type_contents_order
   - unused_capture_list
   - vertical_whitespace_between_cases
+  - json_decoding
 
 attributes:
   always_on_line_above:

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -93,6 +93,7 @@ public let builtInRules: [any Rule.Type] = [
     InertDeferRule.self,
     InvalidSwiftLintCommandRule.self,
     IsDisjointRule.self,
+    JSONDecodingRule.self,
     JoinedDefaultParameterRule.self,
     LargeTupleRule.self,
     LastWhereRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Whatnot/JSONDecodingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Whatnot/JSONDecodingRule.swift
@@ -1,0 +1,76 @@
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule(foldExpressions: true)
+struct JSONDecodingRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "json_decoding",
+        name: "JSON Decoding",
+        description: "Don't use JSONDecoder.decode directly",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                T.decode(data)
+            """),
+            Example("""
+                let decoder = JSONDecoder()
+                MyType.decode(data, using: decoder)
+            """),
+            Example("""
+                MyType.decode(data, using: JSONDecoder().snakeCase())
+            """),
+            Example("""
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let myType = try container.decode(MyType.self, forKey: .myType)
+            """),
+            Example("""
+                let container = try decoder.singleValueContainer().decode(MyType.self)
+            """)
+        ],
+        triggeringExamples: [
+            Example("""
+                JSONDecoder().↓decode(MyType.self, from: data)
+            """),
+            Example("""
+                let decoder = JSONDecoder()
+                decoder.↓decode(MyType.self, from: data)
+            """),
+            Example("""
+                JSONDecoder().snakeCase().↓decode(Self.self, from: data)
+            """)
+        ]
+    )
+}
+
+private extension JSONDecodingRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            guard let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+                  member.declName.baseName.text == "decode",
+                  let argument = node.arguments.first?.expression.as(MemberAccessExprSyntax.self),
+                  let modelName = argument.base?.description,
+                  argument.declName.baseName.text == "self",
+                  let fromArgument = node.arguments.first(where: { $0.label?.text == "from" })
+            else { return }
+
+            violations.append(reason(
+                modelName: modelName,
+                dataName: fromArgument.expression.description,
+                position: member.declName.positionAfterSkippingLeadingTrivia
+            ))
+        }
+
+        func reason(modelName: String, dataName: String, position: AbsolutePosition) -> ReasonedRuleViolation {
+            .init(
+                position: position,
+                reason: """
+                Use `\(modelName).decode(\(dataName))` instead. It will automatically trigger \
+                error logs if the decoding fails
+                """,
+                severity: .warning
+            )
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Whatnot/TextConcatenationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Whatnot/TextConcatenationRule.swift
@@ -57,10 +57,10 @@ private extension TextConcatenationRule {
 
                 if isTextInit {
                     return funcCall
-                } else {
-                    return recursivelySearchForTextInitializerCall(funcCall.calledExpression)
                 }
-            } else if let memberAccess = node.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
+                return recursivelySearchForTextInitializerCall(funcCall.calledExpression)
+            }
+            if let memberAccess = node.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
                 return recursivelySearchForTextInitializerCall(base)
             }
 

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -547,6 +547,12 @@ class IsDisjointRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class JSONDecodingRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(JSONDecodingRule.description)
+    }
+}
+
 class JoinedDefaultParameterRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(JoinedDefaultParameterRule.description)


### PR DESCRIPTION
We recently added some error logging inside `Decodable.decode(_:)` which has already proven very useful. We want to enforce its usage everywhere so we can get as much coverage as possible. on our error logging. To that end, we need to warn against using `JSONDecoder.decode(_:from:)`.