### PR TITLE
Add rule for enforcing SerializableEvent

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,6 +50,7 @@ disabled_rules:
   - type_contents_order
   - vertical_whitespace_between_cases
   - json_decoding
+  - serializable_event
 
 # Configurations
 attributes:

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -191,6 +191,7 @@ public let builtInRules: [any Rule.Type] = [
     ReturnValueFromVoidFunctionRule.self,
     SelfBindingRule.self,
     SelfInPropertyInitializationRule.self,
+    SerializableEventRule.self,
     ShorthandArgumentRule.self,
     ShorthandOperatorRule.self,
     ShorthandOptionalBindingRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Whatnot/SerializableEventRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Whatnot/SerializableEventRule.swift
@@ -1,0 +1,107 @@
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule(foldExpressions: true)
+struct SerializableEventRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "serializable_event",
+        name: "Serializable Events",
+        description: "Ensure that all Events are also SerializableEvents",
+        kind: .lint,
+        nonTriggeringExamples: [
+            // Structs
+            Example("""
+                struct Thing {}
+            """),
+            Example("""
+                struct Thing: SomeOtherProtocol {}
+            """),
+            Example("""
+                struct Thing: SomeOtherProtocolWithEventInTheName {}
+            """),
+            Example("""
+                struct MyEvent: Event, SerializableEvent {}
+            """),
+            // Classes
+            Example("""
+                class Thing {}
+            """),
+            Example("""
+                class Thing: SomeOtherProtocol {}
+            """),
+            Example("""
+                class Thing: SomeOtherProtocolWithEventInTheName {}
+            """),
+            Example("""
+                class MyEvent: Event, SerializableEvent {}
+            """),
+        ],
+        triggeringExamples: [
+            // Struct
+            Example("""
+                struct ↓MyEvent: Event {}
+            """),
+            Example("""
+                struct ↓MyEvent: SerializableEvent {}
+            """),
+            // Class
+            Example("""
+                class ↓MyEvent: Event {}
+            """),
+            Example("""
+                class ↓MyEvent: SerializableEvent {}
+            """),
+        ]
+    )
+}
+
+private extension SerializableEventRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: StructDeclSyntax) {
+            guard let inheritedTypes = node.inheritanceClause?.inheritedTypes else { return }
+            verify(
+                name: node.name.text,
+                position: node.name.positionAfterSkippingLeadingTrivia,
+                inheritedTypes: inheritedTypes
+            )
+        }
+
+        override func visitPost(_ node: ClassDeclSyntax) {
+            guard let inheritedTypes = node.inheritanceClause?.inheritedTypes else { return }
+            verify(
+                name: node.name.text,
+                position: node.name.positionAfterSkippingLeadingTrivia,
+                inheritedTypes: inheritedTypes
+            )
+        }
+
+        private func verify(
+            name: String,
+            position: AbsolutePosition,
+            inheritedTypes: InheritedTypeListSyntax
+        ) {
+            // helper funcs; defined inline so they can conveniently capture variables
+            func adopts(_ type: String) -> Bool {
+                inheritedTypes.contains(where: { $0.type.as(IdentifierTypeSyntax.self)?.typeName == type })
+            }
+
+            func error(_ message: String) {
+                violations.append(ReasonedRuleViolation(
+                    position: position,
+                    reason: "'\(name)' " + message,
+                    severity: configuration.severity
+                ))
+            }
+
+            // Here's the logic
+            if adopts("Event") && !adopts("SerializableEvent") {
+                error("adopts 'Event', so it must also adopt 'SerializableEvent'")
+            }
+            if adopts("SerializableEvent") && !adopts("Event") {
+                error("adopts 'SerializableEvent', so it must also adopt 'Event'")
+            }
+        }
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1135,6 +1135,12 @@ final class SelfInPropertyInitializationRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class SerializableEventRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(SerializableEventRule.description)
+    }
+}
+
 final class ShorthandArgumentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ShorthandArgumentRule.description)

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -882,6 +882,10 @@ self_in_property_initialization:
   severity: warning
   meta:
     opt-in: false
+serializable_event:
+  severity: warning
+  meta:
+    opt-in: false
 shorthand_argument:
   severity: warning
   allow_until_line_after_opening_brace: 4


### PR DESCRIPTION
Add a rule to enforce that any time you adopt `Event`, you must also adopt `SerializableEvent`. See details in the [updated docs in the Event module (in our iOS repo)](https://github.com/Whatnot-Inc/whatnot-ios/pull/17282/files#diff-c9dbf40b1be350b37d6c5846daaaa5926ae65777d4f52ded90fd655de9ec717b)